### PR TITLE
Fix(exception): 에러처리 중앙화

### DIFF
--- a/src/main/java/com/example/demo/ai/ErrorMessage.java
+++ b/src/main/java/com/example/demo/ai/ErrorMessage.java
@@ -1,0 +1,6 @@
+package com.example.demo.ai;
+
+public interface ErrorMessage {
+    String SUCCESS = "요청 성공";
+    String FAILED = "요청 실패";
+}

--- a/src/main/java/com/example/demo/ai/service/GptAssistantService.java
+++ b/src/main/java/com/example/demo/ai/service/GptAssistantService.java
@@ -63,6 +63,11 @@ public class GptAssistantService {
                         .responseFormat(dto.getResponseFormat())
                         .build()
         );
+
+        if(json.getStatusCode().is4xxClientError()){
+            log.warn(json.getBody() + "");
+            return null;
+        }
         try {
             Assistant assistant = objectMapper.readValue(json.getBody(), Assistant.class);
             assistantRepo.save(
@@ -102,6 +107,10 @@ public class GptAssistantService {
     public Run createThreadAndRun(CreateThreadAndRunRequest dto) {
 
         ResponseEntity<String> json = gptAssistantApiService.createThreadAndRun(dto);
+        if(json.getStatusCode().is4xxClientError()){
+            log.warn(json.getBody() + "");
+            return null;
+        }
 
         Long tempUser = 1L;
         User user = userRepo.findById(tempUser).orElseThrow(() -> new RuntimeException("유저가 존재하지 않습니다."));
@@ -151,6 +160,10 @@ public class GptAssistantService {
         String uri = "/v1/threads/" + threadId + "/messages/" + messageId;
         ResponseEntity<String> json = gptAssistantApiService.getMessage(threadId,messageId);
 
+        if(json.getStatusCode().is4xxClientError()){
+            log.warn(json.getBody() + "");
+            return null;
+        }
         try {
             return objectMapper.readValue(json.getBody(), Message.class);
         } catch (JsonProcessingException e) {
@@ -170,6 +183,10 @@ public class GptAssistantService {
     public MessageList getMessages(String threadId) {
         String uri = "/v1/threads/" + threadId + "/messages";
         ResponseEntity<String> json = gptAssistantApiService.getMessages(threadId);
+        if(json.getStatusCode().is4xxClientError()){
+            log.warn(json.getBody() + "");
+            return null;
+        }
         try {
             return objectMapper.readValue(json.getBody(), MessageList.class);
         } catch (JsonProcessingException e) {
@@ -189,6 +206,10 @@ public class GptAssistantService {
      */
     public Run getRun(String threadId, String runId) {
         ResponseEntity<String> json = gptAssistantApiService.getRuns(threadId,runId);
+        if(json.getStatusCode().is4xxClientError()){
+            log.warn(json.getBody() + "");
+            return null;
+        }
         try {
             return objectMapper.readValue(json.getBody(), Run.class);
         } catch (JsonProcessingException e) {
@@ -204,6 +225,10 @@ public class GptAssistantService {
      * */
     public AssistantList getAssistants(){
         ResponseEntity<String> json = gptAssistantApiService.getAssistants();
+        if(json.getStatusCode().is4xxClientError()){
+            log.warn(json.getBody() + "");
+            return null;
+        }
         try {
             return objectMapper.readValue(json.getBody(),AssistantList.class);
         }catch (JsonProcessingException e){

--- a/src/main/java/com/example/demo/ai/service/GptService.java
+++ b/src/main/java/com/example/demo/ai/service/GptService.java
@@ -12,6 +12,8 @@ import com.example.demo.ai.entity.AssistantEntity;
 import com.example.demo.ai.repo.AssistantRepo;
 import com.example.demo.ai.service.dto.DailyCodyReqDto;
 import com.example.demo.ai.service.dto.DailyCodyResDto;
+import com.example.demo.exception.ErrorCode;
+import com.example.demo.exception.GlobalException;
 import com.example.demo.weather.dto.srt_fcst.FcstItem;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,6 +38,9 @@ public class GptService {
      * @param fcstItems 당일 혹은 예상 일기예보 n개를 인자로 받습니다.
      */
     public DailyCodyResDto generateDailyCodyCategory(List<FcstItem> fcstItems) {
+        if(fcstItems.size() > 12){
+            throw new GlobalException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
         if (fcstItems.size() > 10) {
             fcstItems = fcstItems.subList(fcstItems.size() - 10, fcstItems.size());
         }

--- a/src/main/java/com/example/demo/exception/ErrorCode.java
+++ b/src/main/java/com/example/demo/exception/ErrorCode.java
@@ -1,0 +1,21 @@
+package com.example.demo.exception;
+
+import com.example.demo.ai.ErrorMessage;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.","argument check"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메서드입니다.","method check"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류입니다.","서버오류");
+
+    private HttpStatus status;
+    private String message;
+    private String logMessage;
+
+
+}

--- a/src/main/java/com/example/demo/exception/ErrorResponse.java
+++ b/src/main/java/com/example/demo/exception/ErrorResponse.java
@@ -1,0 +1,22 @@
+package com.example.demo.exception;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+
+    private final LocalDateTime timestamp = LocalDateTime.now();
+    private final int status;
+    private final String error;
+    private final String code;
+    private final String message;
+
+    public ErrorResponse(ErrorCode errorCode) {
+        this.status = errorCode.getStatus().value();
+        this.error = errorCode.getStatus().name();
+        this.code = errorCode.name();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/com/example/demo/exception/GlobalException.java
+++ b/src/main/java/com/example/demo/exception/GlobalException.java
@@ -1,0 +1,10 @@
+package com.example.demo.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GlobalException extends RuntimeException{
+    public ErrorCode errorCode;
+}

--- a/src/main/java/com/example/demo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/demo/exception/GlobalExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.example.demo.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * <p>Controller 단에서 발생하는 모든 에러를 중앙에서 관리하기 위한 핸들러입니다. <br/>
+ * Filter 에서 발생한 에러는 Controller까지 전파되지 않으니 주의 해주세요.
+ * </p>
+ * */
+
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    /**
+     * 커스텀 에러
+     */
+    @ExceptionHandler(GlobalException.class)
+    protected ResponseEntity<ErrorResponse> handleCustomException(final GlobalException e) {
+        log.error("handleCustomException: {}", e.getErrorCode());
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus().value())
+                .body(new ErrorResponse(e.getErrorCode()));
+    }
+
+    /**
+     * HTTP 405 Exception
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(final HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.METHOD_NOT_ALLOWED.getStatus().value())
+                .body(new ErrorResponse(ErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    /**
+     * HTTP 500 Exception
+     */
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(final Exception e) {
+        log.error("handleException: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus().value())
+                .body(new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+
+}


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 💡 작업동기
- 프론트에 500에러가 도착하면 구체적인 이유를 몰라서 다음 로직 작성하기가 어려움

### 🔑 주요 변경사항
- 에러처리 중앙화를 위한 메서드 구현 및 에러코드 정의

### 사용가이드
에러 발생 시키고 싶은 곳에서 아래 형태로 작성
```java

  throw new GlobalException(ErrorCode.BAD_REQUEST);
```

에러 코드는 아래 파일에 작성되어있음
**`excpetion/ErrorCode`**
```java 

@Getter
@AllArgsConstructor
public enum ErrorCode {
    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.","argument check"),
    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메서드입니다.","method check"),
    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류입니다.","서버오류");
    
    // example
    // ERROR_001(HttpStatus.BAD_REQUEST,"프론트로 보낼 메시지","로깅용 메시지")

    private HttpStatus status;
    private String message;
    private String logMessage;
}
```





